### PR TITLE
tox.ini: use extras, use python3 for docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@ envlist =
 commands =
     zope-testrunner --test-path=src []
     sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
-deps =
-    .[test,docs]
+extras = test,docs
 
 [testenv:coverage]
 usedevelop = true
@@ -16,14 +15,13 @@ basepython =
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
-    coverage report --fail-under=100
+    coverage report -m --fail-under=100
 deps =
-    {[testenv]deps}
     coverage
 
 [testenv:docs]
 basepython =
-    python2.7
+    python3
 commands =
-    sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+    sphinx-build -b html    -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
We still need to use Python 2 for coverage because we have a bunch of
Python-2-only fallback paths in exceptionformatter.py.