### PR TITLE
Adapt to python 3.10 SyntaxError messages

### DIFF
--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -668,7 +668,7 @@ class Test_format_exception(unittest.TestCase):
         self.assertEqual(lines[0], '    syntax error')
         # PyPy has a shorter prefix
         self.assertTrue(lines[1].endswith('    ^'))
-        self.assertRegex(lines[2], '^SyntaxError: invalid syntax')
+        self.assertTrue(lines[2].startswith('SyntaxError: invalid syntax'), lines[2])
 
     def test_traceback_info_non_ascii(self):
         __traceback_info__ = u"Have a Snowman: \u2603"

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -668,7 +668,7 @@ class Test_format_exception(unittest.TestCase):
         self.assertEqual(lines[0], '    syntax error')
         # PyPy has a shorter prefix
         self.assertTrue(lines[1].endswith('    ^'))
-        self.assertEqual(lines[2], 'SyntaxError: invalid syntax')
+        self.assertRegex(lines[2], '^SyntaxError: invalid syntax')
 
     def test_traceback_info_non_ascii(self):
         __traceback_info__ = u"Have a Snowman: \u2603"


### PR DESCRIPTION
SyntaxError messages are becoming more verbose in python 3.10. See [here](https://docs.python.org/3.10/whatsnew/3.10.html#better-error-messages) for more info. As a result, one test fails on python 3.10.

This patch was tested on python 3.7, 3.8, 3.9, 3.10, pypy3 - all passes with it.
If it is relavent, this patch will fail on python < 3.1.