### PR TITLE
More adaption to Python 3.10 syntax error message

### DIFF
--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -666,8 +666,7 @@ class Test_format_exception(unittest.TestCase):
             s = self._callFUT(False)
         lines = s.splitlines()[-3:]
         self.assertEqual(lines[0], '    syntax error')
-        # PyPy has a shorter prefix
-        self.assertTrue(lines[1].endswith('    ^'))
+        self.assertIn('    ^', lines[1])
         self.assertTrue(lines[2].startswith('SyntaxError: invalid syntax'),
                         lines[2])
 


### PR DESCRIPTION
This is a follow up to #19. Note the varying position of the caret. I don't have pypy installed, but I suspect the comment is related.

```
$ python2.7 -c 'syntax error'
  File "<string>", line 1
    syntax error
               ^
SyntaxError: invalid syntax
$ python3.6 -c 'syntax error'
  File "<string>", line 1
    syntax error
               ^
SyntaxError: invalid syntax
$ python3.8 -c 'syntax error'
  File "<string>", line 1
    syntax error
           ^
SyntaxError: invalid syntax
$ python3.9 -c 'syntax error'
  File "<string>", line 1
    syntax error
           ^
SyntaxError: invalid syntax
$ python3.10 -c 'syntax error'
  File "<string>", line 1
    syntax error
           ^^^^^
SyntaxError: invalid syntax
```