### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,12 +28,14 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
-        - ["pypy2", "pypy"]
-        - ["pypy3", "pypy3"]
+        - ["3.11",  "py311"]
+        - ["pypy-2.7", "pypy"]
+        - ["pypy-3.7", "pypy3"]
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "121e74bd9c9718abd9a1a079e6ede252c1a0ba7d"
+commit-id = "b4dd6f9ffd3d6a2cde7dc70512c62d4c7ed22cd6"
 
 [python]
 with-pypy = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@
 4.6 (unreleased)
 ================
 
+- Catch exceptions in ``formatExceptionOnly``.
+  Getting an exception when reporting about a different exception is not helpful.
+  On Python 3.11 this is needed for some HTTPErrors.
+
 - Add official support for Python 3.11.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.6 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add official support for Python 3.11.
 
 
 4.5 (2022-02-11)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,14 @@ ignore =
     .meta.toml
     docs/_build/html/_sources/*
     docs/_build/doctest/*
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@
 """Setup for zope.exceptions package
 """
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read(*rnames):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',

--- a/src/zope/exceptions/__init__.py
+++ b/src/zope/exceptions/__init__.py
@@ -17,14 +17,14 @@ These exceptions are so general purpose that they don't belong in Zope
 application-specific packages.
 """
 
-from zope.exceptions.interfaces import DuplicationError
-from zope.exceptions.interfaces import IDuplicationError
-from zope.exceptions.interfaces import UserError
-from zope.exceptions.interfaces import IUserError
-
+from zope.exceptions.exceptionformatter import extract_stack
 from zope.exceptions.exceptionformatter import format_exception
 from zope.exceptions.exceptionformatter import print_exception
-from zope.exceptions.exceptionformatter import extract_stack
+from zope.exceptions.interfaces import DuplicationError
+from zope.exceptions.interfaces import IDuplicationError
+from zope.exceptions.interfaces import IUserError
+from zope.exceptions.interfaces import UserError
+
 
 __all__ = [
     'DuplicationError', 'IDuplicationError', 'UserError', 'IUserError',
@@ -40,12 +40,12 @@ except ImportError as v:  # pragma: no cover
     if 'security' not in str(v):
         raise
 else:  # pragma: no cover
-    from zope.security.interfaces import IUnauthorized
-    from zope.security.interfaces import Unauthorized
-    from zope.security.interfaces import IForbidden
-    from zope.security.interfaces import IForbiddenAttribute
     from zope.security.interfaces import Forbidden
     from zope.security.interfaces import ForbiddenAttribute
+    from zope.security.interfaces import IForbidden
+    from zope.security.interfaces import IForbiddenAttribute
+    from zope.security.interfaces import IUnauthorized
+    from zope.security.interfaces import Unauthorized
     __all__ += [
         'IUnauthorized', 'Unauthorized', 'IForbidden', 'IForbiddenAttribute',
         'Forbidden', 'ForbiddenAttribute',

--- a/src/zope/exceptions/exceptionformatter.py
+++ b/src/zope/exceptions/exceptionformatter.py
@@ -15,12 +15,16 @@
 optionally in HTML.
 """
 import sys
+
+
 try:
     from html import escape
 except ImportError:  # pragma: PY2
     from cgi import escape
+
 import linecache
 import traceback
+
 
 DEBUG_EXCEPTION_FORMATTER = 1
 

--- a/src/zope/exceptions/exceptionformatter.py
+++ b/src/zope/exceptions/exceptionformatter.py
@@ -177,7 +177,8 @@ class TextExceptionFormatter(object):
         # See https://github.com/python/cpython/issues/90113
         try:
             result = ''.join(traceback.format_exception_only(etype, value))
-        except Exception:
+        except Exception:  # pragma: no cover
+            # This code branch is only covered on Python 3.11.
             result = str(value)
         return result
 

--- a/src/zope/exceptions/exceptionformatter.py
+++ b/src/zope/exceptions/exceptionformatter.py
@@ -171,7 +171,14 @@ class TextExceptionFormatter(object):
         return self.line_sep.join(result)
 
     def formatExceptionOnly(self, etype, value):
-        result = ''.join(traceback.format_exception_only(etype, value))
+        # We don't want to get an error when we format an error, so we
+        # compensate in our code.  For example, on Python 3.11.0 HTTPError
+        # gives an unhelpful KeyError in tempfile when Python formats it.
+        # See https://github.com/python/cpython/issues/90113
+        try:
+            result = ''.join(traceback.format_exception_only(etype, value))
+        except Exception:
+            result = str(value)
         return result
 
     def formatLastLine(self, exc_line):

--- a/src/zope/exceptions/interfaces.py
+++ b/src/zope/exceptions/interfaces.py
@@ -28,8 +28,8 @@ arguments to pass to the factory.  The traceback formatter makes an
 effort to clearly present the information provided by the
 ITracebackSupplement.
 """
-from zope.interface import Interface
 from zope.interface import Attribute
+from zope.interface import Interface
 from zope.interface import implementer
 
 

--- a/src/zope/exceptions/log.py
+++ b/src/zope/exceptions/log.py
@@ -14,10 +14,11 @@
 """Log formatter that enhances tracebacks with extra information.
 """
 
-import logging
 import io
+import logging
 
 from zope.exceptions.exceptionformatter import print_exception
+
 
 Buffer = io.StringIO if bytes is not str else io.BytesIO  # PY2
 

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -886,8 +886,11 @@ class DummySupplement(object):
 
 
 class DummyTB(object):
+    # https://docs.python.org/3/reference/datamodel.html#traceback-objects
+    tb_frame = None
     tb_lineno = 14
     tb_next = None
+    tb_lasti = -1
 
 
 class DummyFrame(object):
@@ -903,6 +906,12 @@ class DummyFrame(object):
 class DummyCode(object):
     co_filename = 'dummy/filename.py'
     co_name = 'dummy_function'
+
+    def co_positions(self):
+        # New in Python 3.11.
+        # https://docs.python.org/3/reference/datamodel.html#codeobject.co_positions
+        # This is not called for DummyTB because there tb_lasti is -1.
+        return (None, None, None, None)
 
 
 class _Monkey(object):

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -278,6 +278,47 @@ class TextExceptionFormatterTests(unittest.TestCase):
                          ''.join(
                              traceback.format_exception_only(ValueError, err)))
 
+    def test_formatExceptionOnly_httperror(self):
+        # On Python 3.11.0 HTTPError may behave wrongly, giving a KeyError in
+        # tempfile when Python tries to format it.
+        # See https://github.com/python/cpython/issues/90113
+        # or examples in Plone tests, especially doctests:
+        # https://github.com/plone/Products.CMFPlone/issues/3663
+        # We don't want to get an error when we format an error,
+        # so let's compensate in our code.
+        try:
+            from urllib.error import HTTPError
+        except ImportError:
+            # BBB for Python 2.7
+            from urllib2 import HTTPError
+        fmt = self._makeOne()
+        err = HTTPError('url', 400, 'oops', [], None)
+        result = fmt.formatExceptionOnly(HTTPError, err).strip()
+        # The output can differ too much per Python version,
+        # but it is just one line when stripped.
+        self.assertIn("400", result)
+        self.assertIn("oops", result)
+        self.assertIn("Error", result)
+        self.assertEqual(len(result.splitlines()), 1)
+
+    def test_formatException_httperror(self):
+        # See test_formatExceptionOnly_httperror.
+        # Here we check that formatException works.
+        try:
+            from urllib.error import HTTPError
+        except ImportError:
+            # BBB for Python 2.7
+            from urllib2 import HTTPError
+        fmt = self._makeOne()
+        err = HTTPError('url', 400, 'oops', [], None)
+        result = fmt.formatException(HTTPError, err, None)
+        self.assertEqual(result[0], 'Traceback (most recent call last):\n')
+        last = result[-1]
+        # The output can differ per Python version.
+        self.assertIn("400", last)
+        self.assertIn("oops", last)
+        self.assertIn("Error", last)
+
     def test_formatLastLine(self):
         fmt = self._makeOne()
         self.assertEqual(fmt.formatLastLine('XXX'), 'XXX')

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -17,6 +17,13 @@ import sys
 import unittest
 
 
+try:
+    from urllib.error import HTTPError
+except ImportError:
+    # BBB for Python 2.7
+    from urllib2 import HTTPError
+
+
 IS_PY39_OR_GREATER = sys.version_info >= (3, 9)
 
 
@@ -286,11 +293,6 @@ class TextExceptionFormatterTests(unittest.TestCase):
         # https://github.com/plone/Products.CMFPlone/issues/3663
         # We don't want to get an error when we format an error,
         # so let's compensate in our code.
-        try:
-            from urllib.error import HTTPError
-        except ImportError:
-            # BBB for Python 2.7
-            from urllib2 import HTTPError
         fmt = self._makeOne()
         err = HTTPError('url', 400, 'oops', [], None)
         result = fmt.formatExceptionOnly(HTTPError, err).strip()
@@ -304,11 +306,6 @@ class TextExceptionFormatterTests(unittest.TestCase):
     def test_formatException_httperror(self):
         # See test_formatExceptionOnly_httperror.
         # Here we check that formatException works.
-        try:
-            from urllib.error import HTTPError
-        except ImportError:
-            # BBB for Python 2.7
-            from urllib2 import HTTPError
         fmt = self._makeOne()
         err = HTTPError('url', 400, 'oops', [], None)
         result = fmt.formatException(HTTPError, err, None)
@@ -955,7 +952,7 @@ class DummyCode(object):
         # The 27 in the return value is chosen to match tb_recurse.tb_lineno=27
         # in test_formatException_recursion_in_tb_stack in this file.
         # The rest is random.
-        # Note that this code is only called on Python 3.11, so we mark it for
+        # Note that this code is only called on Python 3.11+, so we mark it for
         # the coverage tool.
         return [(27, 2, 3, 4)]  # pragma: no cover
 

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -931,7 +931,7 @@ class DummyTB(object):
     tb_frame = None
     tb_lineno = 14
     tb_next = None
-    tb_lasti = -1
+    tb_lasti = 1
 
 
 class DummyFrame(object):
@@ -951,8 +951,13 @@ class DummyCode(object):
     def co_positions(self):
         # New in Python 3.11.
         # https://docs.python.org/3/reference/datamodel.html#codeobject.co_positions
-        # This is not called for DummyTB because there tb_lasti is -1.
-        return (None, None, None, None)
+        # Note that this is not called for DummyTB if you have tb_lasti=-1.
+        # The 27 in the return value is chosen to match tb_recurse.tb_lineno=27
+        # in test_formatException_recursion_in_tb_stack in this file.
+        # The rest is random.
+        # Note that this code is only called on Python 3.11, so we mark it for
+        # the coverage tool.
+        return [(27, 2, 3, 4)]  # pragma: no cover
 
 
 class _Monkey(object):

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -13,8 +13,8 @@
 ##############################################################################
 """ExceptionFormatter tests.
 """
-import unittest
 import sys
+import unittest
 
 
 IS_PY39_OR_GREATER = sys.version_info >= (3, 9)
@@ -709,9 +709,10 @@ class Test_format_exception(unittest.TestCase):
 
     def test_format_exception_as_html(self):
         # Test for format_exception (as_html=True)
-        from zope.exceptions.exceptionformatter import format_exception
-        from textwrap import dedent
         import re
+        from textwrap import dedent
+
+        from zope.exceptions.exceptionformatter import format_exception
         try:
             exec('import')
         except SyntaxError:

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pypy
     pypy3
     docs
@@ -29,15 +30,25 @@ extras =
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-    flake8
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
 commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
This PR updates this repo to the latest meta config, plus some fixes.

See the [Python 3.11 docs](https://docs.python.org/3/whatsnew/3.11.html?highlight=co_positions#new-features) for a few things that have changed in Python 3.11, especially for exceptions. One of those gives problems for `zope.exceptions`, at least in the tests. That is PEP 657: Fine-grained error locations in tracebacks. See issue #25 that @icemac reported earlier this year. That is fixed with this PR.

I don't know if anything needs to change for two other new features in 3.11, I did not try them out:

- PEP 654: Exception Groups and except*
- PEP 678: Exceptions can be enriched with notes

I have also fixed a possible problem printing info about `HTTPError` in Python 3.11. In practice this worked fine, but it gave [problems in a few Plone tests](https://github.com/plone/Products.CMFPlone/issues/3663), though I am solving them in a different way in Plone PRs.

Fixes #25.