### PR TITLE
Fix `HTMLExceptionFormatter` when using non-str `__traceback_info__`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix issue introduced in the last release which is breaking
+  ``HTMLExceptionFormatter`` when using non-str ``__traceback_info__``.
 
 
 5.0 (2023-06-29)

--- a/src/zope/exceptions/exceptionformatter.py
+++ b/src/zope/exceptions/exceptionformatter.py
@@ -248,7 +248,7 @@ class HTMLExceptionFormatter(TextExceptionFormatter):
     line_sep = '<br />\r\n'
 
     def escape(self, s):
-        return escape(s, quote=False)
+        return escape(str(s), quote=False)
 
     def getPrefix(self):
         return '<p>Traceback (most recent call last):</p>\r\n<ul>'

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -514,6 +514,10 @@ class HTMLExceptionFormatterTests(unittest.TestCase):
         fmt = self._makeOne()
         self.assertEqual(fmt.escape('XXX'), 'XXX')
 
+    def test_escape_non_str(self):
+        fmt = self._makeOne()
+        self.assertEqual(fmt.escape(123), '123')
+
     def test_escape_w_markup(self):
         fmt = self._makeOne()
         self.assertEqual(fmt.escape('<span>XXX & YYY<span>'),


### PR DESCRIPTION
This PR recreates the previous behaviour which was marked `PY2` there, so I removed it.

Currently the tests of several packages are broken because of this issue, e. g.:

* [zope.app.wsgi](https://github.com/zopefoundation/zope.app.wsgi)
* [zope.app.publication](https://github.com/zopefoundation/zope.app.publication)
* [grok](https://github.com/zopefoundation/grok)