### PR TITLE
Include code from PEP302 loaders in tracebacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add support for Python 3.12.
 
+- Include code from PEP302 loaders in tracebacks
+
 
 5.0.1 (2023-07-11)
 ==================

--- a/src/zope/exceptions/exceptionformatter.py
+++ b/src/zope/exceptions/exceptionformatter.py
@@ -123,6 +123,7 @@ class TextExceptionFormatter:
         result.append(self.escape(s))
 
         # Append the source line, if available
+        linecache.lazycache(filename, f_globals)
         line = linecache.getline(filename, lineno)
         if line:
             result.append("    " + self.escape(line.strip()))

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -792,10 +792,10 @@ class Test_format_exception(unittest.TestCase):
             with zipfile.ZipFile(module_zipfile, "w") as zf:
                 zf.writestr(
                     zipfile.ZipInfo(f"{module_name}/__init__.py"),
-                    """
-def f():
-    1 / 0
-""")
+                    textwrap.dedent("""
+                        def f():
+                            1 / 0
+                    """)
             sys.path.insert(0, str(module_zipfile))
             try:
                 importlib.import_module(module_name).f()

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -795,7 +795,7 @@ class Test_format_exception(unittest.TestCase):
                     textwrap.dedent("""
                         def f():
                             1 / 0
-                    """)
+                    """))
             sys.path.insert(0, str(module_zipfile))
             try:
                 importlib.import_module(module_name).f()

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -17,8 +17,8 @@ import importlib
 import pathlib
 import sys
 import tempfile
-import unittest
 import textwrap
+import unittest
 import zipfile
 from urllib.error import HTTPError
 

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -18,6 +18,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+import textwrap
 import zipfile
 from urllib.error import HTTPError
 
@@ -748,14 +749,13 @@ class Test_format_exception(unittest.TestCase):
     def test_format_exception_as_html(self):
         # Test for format_exception (as_html=True)
         import re
-        from textwrap import dedent
 
         from zope.exceptions.exceptionformatter import format_exception
         try:
             exec('import')
         except SyntaxError:
             result = ''.join(format_exception(*sys.exc_info(), as_html=True))
-        expected = dedent("""\
+        expected = textwrap.dedent("""\
             <p>Traceback (most recent call last):</p>
             <ul>
             <li>  Module {module}, line ABC, in {fn}<br />

--- a/src/zope/exceptions/tests/test_exceptionformatter.py
+++ b/src/zope/exceptions/tests/test_exceptionformatter.py
@@ -13,8 +13,12 @@
 ##############################################################################
 """ExceptionFormatter tests.
 """
+import importlib
+import pathlib
 import sys
+import tempfile
 import unittest
+import zipfile
 from urllib.error import HTTPError
 
 
@@ -773,6 +777,32 @@ class Test_format_exception(unittest.TestCase):
         result = re.sub(r'line \d\d\d,', 'line ABC,', result)
         self.maxDiff = None
         self.assertEqual(expected, result)
+
+    def test_pep302_loader_source_in_traceback(self):
+        sys_path = sys.path[::]
+
+        def restore_sys_path():
+            sys.path[::] = sys_path
+        self.addCleanup(restore_sys_path)
+
+        module_name = self._testMethodName
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            module_zipfile = td / f"{module_name}.zip"
+            with zipfile.ZipFile(module_zipfile, "w") as zf:
+                zf.writestr(
+                    zipfile.ZipInfo(f"{module_name}/__init__.py"),
+                    """
+def f():
+    1 / 0
+""")
+            sys.path.insert(0, str(module_zipfile))
+            try:
+                importlib.import_module(module_name).f()
+            except ZeroDivisionError:
+                s = self._callFUT(False)
+
+        self.assertIn('1 / 0', s)
 
 
 class Test_print_exception(unittest.TestCase):


### PR DESCRIPTION
Since cpython commit [6bc2c1e7eb](https://github.com/python/cpython/commit/6bc2c1e7ebf359224e5e547f58ffc2c42cb36a39) , included since python 3.5, `linecache` module exposes a new `lazycache` function that needs to be called to capture information for modules not based on files.

The tests are based on zipimport, because it's a simple and realistic way of using such a loader.